### PR TITLE
add dependency for deprecated Stream module

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,6 +14,7 @@
   (coq (and (>= 8.15) (< 8.16)))
   ; ocaml-lsp-server
   coq-hammer
+  (camlp-streams (>= 5.0.1))
  )
  (synopsis "SMT integration for Coq using reflection")
  (description  "SMT integration for Coq using reflection")

--- a/mirrorsolve.opam
+++ b/mirrorsolve.opam
@@ -14,6 +14,7 @@ depends: [
   "coq-metacoq" {= "1.0+8.15"}
   "coq" {>= "8.15" & < "8.16"}
   "coq-hammer"
+  "camlp-streams" {>= "5.0.1"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/dune
+++ b/src/dune
@@ -20,6 +20,7 @@
    coq-core.tactics
    coq-core.vernac                       ; needed for vernac extend
    coq-core.plugins.ltac                 ; needed for tactic extend
+   camlp-streams                         ; needed for Stream module
  )
  ; (modules (:standard \ Hint))
 )


### PR DESCRIPTION
Stream [was deprecated in ocaml 4.14](https://ocaml.org/releases/4.14.0) and moved to a library `camlp-streams`. This PR uses that library instead of the old stdlib Stream.